### PR TITLE
Migrate web conditional import

### DIFF
--- a/lib/screens/shared.dart
+++ b/lib/screens/shared.dart
@@ -1,3 +1,3 @@
 export 'unsupported.dart'
-    if (dart.library.html) 'web.dart'
+    if (dart.library.js_interop) 'web.dart'
     if (dart.library.io) 'io_device.dart';


### PR DESCRIPTION
When I migrated to web library in https://github.com/CodingWithTashi/simple_barcode_scanner/pull/52, I forgot to migrate the conditional import. This will enable support to wasm compilation.

[Migrate to package:web](https://dart.dev/interop/js-interop/package-web#conditional-imports)