### PR TITLE
Add option to scan only barcode, QR Code, or Both

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,7 @@
 include: package:flutter_lints/flutter.yaml
 
+analyzer:
+  errors:
+    constant_identifier_names: ignore
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/android/src/main/java/com/amolg/flutterbarcodescanner/BarcodeCaptureActivity.java
+++ b/android/src/main/java/com/amolg/flutterbarcodescanner/BarcodeCaptureActivity.java
@@ -74,6 +74,27 @@ public final class BarcodeCaptureActivity extends AppCompatActivity implements B
 
     // constants used to pass extra data in the intent
     public static final String BarcodeObject = "Barcode";
+    public static final int BARCODE_FORMATS =
+        Barcode.CODABAR
+                | Barcode.CODE_128
+                | Barcode.CODE_39
+                | Barcode.CODE_93
+                | Barcode.EAN_13
+                | Barcode.EAN_8
+                | Barcode.ISBN
+                | Barcode.ITF
+                | Barcode.PDF417
+                | Barcode.PRODUCT
+                | Barcode.UPC_A
+                | Barcode.UPC_E;
+
+    public static final int QR_CODE_FORMATS = Barcode.QR_CODE;
+    public static SCAN_FORMAT_ENUM SCAN_FORMAT = SCAN_FORMAT_ENUM.ALL_FORMATS;
+    public enum SCAN_FORMAT_ENUM {
+        ALL_FORMATS,
+        ONLY_QR_CODE,
+        ONLY_BARCODE
+    }
 
     private CameraSource mCameraSource;
     private CameraSourcePreview mPreview;
@@ -220,11 +241,15 @@ public final class BarcodeCaptureActivity extends AppCompatActivity implements B
 
         int delayMillis = (int) getIntent().getIntExtra("delayMillis", 0);
 
+        int barcodeFormats = getFormats();
+
         // A barcode detector is created to track barcodes.  An associated multi-processor instance
         // is set to receive the barcode detection results, track the barcodes, and maintain
         // graphics for each barcode on screen.  The factory is used by the multi-processor to
         // create a separate tracker instance for each barcode.
-        BarcodeDetector barcodeDetector = new BarcodeDetector.Builder(context).build();
+        BarcodeDetector barcodeDetector = new BarcodeDetector.Builder(context)
+            .setBarcodeFormats(barcodeFormats)
+            .build();
         Log.d("BarcodeCaptureActivity", "Barcode detector set up:"+delayMillis);
         BarcodeTrackerFactory barcodeFactory = new BarcodeTrackerFactory(mGraphicOverlay, this,delayMillis);
         barcodeDetector.setProcessor(
@@ -262,6 +287,17 @@ public final class BarcodeCaptureActivity extends AppCompatActivity implements B
             mCameraSource.release();
         }
         mCameraSource = builder.build();
+    }
+
+    private static int getFormats() {
+        int barcodeFormats = Barcode.ALL_FORMATS;
+        if (SCAN_FORMAT == SCAN_FORMAT_ENUM.ONLY_QR_CODE){
+            barcodeFormats = QR_CODE_FORMATS;
+        }
+        if(SCAN_FORMAT == SCAN_FORMAT_ENUM.ONLY_BARCODE){
+            barcodeFormats = BARCODE_FORMATS;
+        }
+        return barcodeFormats;
     }
 
     /**

--- a/android/src/main/java/com/amolg/flutterbarcodescanner/FlutterBarcodeScannerPlugin.java
+++ b/android/src/main/java/com/amolg/flutterbarcodescanner/FlutterBarcodeScannerPlugin.java
@@ -116,6 +116,8 @@ public class FlutterBarcodeScannerPlugin implements MethodCallHandler, ActivityR
                     BarcodeCaptureActivity.SCAN_MODE = BarcodeCaptureActivity.SCAN_MODE_ENUM.QR.ordinal();
                 }
 
+                setScanFormat();
+
                 isContinuousScan = (boolean) arguments.get("isContinuousScan");
 
                 cameraFacingText = (String) arguments.get("cameraFacingText");
@@ -129,6 +131,24 @@ public class FlutterBarcodeScannerPlugin implements MethodCallHandler, ActivityR
         } catch (Exception e) {
             Log.e(TAG, "onMethodCall: " + e.getLocalizedMessage());
         }
+    }
+
+    private void setScanFormat() {
+        BarcodeCaptureActivity.SCAN_FORMAT_ENUM format = BarcodeCaptureActivity.SCAN_FORMAT_ENUM.ALL_FORMATS;
+        if (null != arguments.get("scanFormat")) {
+            String scanFormat = (String) arguments.get("scanFormat");
+
+            assert scanFormat != null;
+            switch (scanFormat.toUpperCase()) {
+                case "ONLY_QR_CODE":
+                    format = BarcodeCaptureActivity.SCAN_FORMAT_ENUM.ONLY_QR_CODE;
+                    break;
+                case "ONLY_BARCODE":
+                    format = BarcodeCaptureActivity.SCAN_FORMAT_ENUM.ONLY_BARCODE;
+                    break;
+            }
+        }
+        BarcodeCaptureActivity.SCAN_FORMAT = format;
     }
 
     private void startBarcodeScannerActivityView(String buttonText, boolean isContinuousScan, String cameraFacingText) {

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -45,5 +45,7 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>Camera permission is required for barcode scanning.</string>
 </dict>
 </plist>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -50,8 +50,9 @@ class _HomePageState extends State<HomePage> {
                     backButtonIcon: Icon(Icons.arrow_back_ios),
                   ),
                   isShowFlashIcon: true,
-                  delayMillis: 2000,
-                  cameraFace: CameraFace.front,
+                  delayMillis: 500,
+                  cameraFace: CameraFace.back,
+                  scanFormat: ScanFormat.ALL_FORMATS,
                 );
                 setState(() {
                   result = res as String;

--- a/ios/Classes/SwiftFlutterBarcodeScannerPlugin.swift
+++ b/ios/Classes/SwiftFlutterBarcodeScannerPlugin.swift
@@ -12,6 +12,40 @@ enum ScanMode:Int{
     }
 }
 
+enum ScanFormat {
+  case ALL_FORMATS
+  case ONLY_QR_CODE
+  case ONLY_BARCODE
+}
+
+let ALL_FORMATS =  [AVMetadataObject.ObjectType.upce,
+                    AVMetadataObject.ObjectType.code39,
+                    AVMetadataObject.ObjectType.code39Mod43,
+                    AVMetadataObject.ObjectType.code93,
+                    AVMetadataObject.ObjectType.code128,
+                    AVMetadataObject.ObjectType.ean8,
+                    AVMetadataObject.ObjectType.ean13,
+                    AVMetadataObject.ObjectType.aztec,
+                    AVMetadataObject.ObjectType.pdf417,
+                    AVMetadataObject.ObjectType.itf14,
+                    AVMetadataObject.ObjectType.dataMatrix,
+                    AVMetadataObject.ObjectType.interleaved2of5,
+                    AVMetadataObject.ObjectType.qr]
+
+let ONLY_QR_CODE = [AVMetadataObject.ObjectType.qr]
+
+let ONLY_BARCODE = [
+  AVMetadataObject.ObjectType.code128,
+  AVMetadataObject.ObjectType.code39,
+  AVMetadataObject.ObjectType.code39Mod43,
+  AVMetadataObject.ObjectType.code93,
+  AVMetadataObject.ObjectType.ean13,
+  AVMetadataObject.ObjectType.ean8,
+  AVMetadataObject.ObjectType.interleaved2of5,
+  AVMetadataObject.ObjectType.itf14,
+  AVMetadataObject.ObjectType.pdf417,
+  AVMetadataObject.ObjectType.upce];
+
 public class SwiftFlutterBarcodeScannerPlugin: NSObject, FlutterPlugin, ScanBarcodeDelegate,FlutterStreamHandler {
     
     public static var viewController = UIViewController()
@@ -97,10 +131,25 @@ public class SwiftFlutterBarcodeScannerPlugin: NSObject, FlutterPlugin, ScanBarc
         }else{
             SwiftFlutterBarcodeScannerPlugin.scanMode = ScanMode.QR.index
         }
+
+        let scanFormat: ScanFormat
+        if let scanFormatReceived = args["scanFormat"] as? String {
+            switch scanFormatReceived {
+                case "ONLY_BARCODE":
+                    scanFormat = .ONLY_BARCODE
+                case "ONLY_QR_CODE":
+                    scanFormat = .ONLY_QR_CODE
+                default:
+                    scanFormat = .ALL_FORMATS
+            }
+        } else {
+            scanFormat = .ALL_FORMATS
+        }
         
         pendingResult=result
         let controller = BarcodeScannerViewController()
         controller.delegate = self
+        controller.setScanFormat(format: scanFormat)
         
         if #available(iOS 13.0, *) {
             controller.modalPresentationStyle = .fullScreen
@@ -156,19 +205,8 @@ protocol ScanBarcodeDelegate {
 }
 
 class BarcodeScannerViewController: UIViewController {
-    private let supportedCodeTypes = [AVMetadataObject.ObjectType.upce,
-                                      AVMetadataObject.ObjectType.code39,
-                                      AVMetadataObject.ObjectType.code39Mod43,
-                                      AVMetadataObject.ObjectType.code93,
-                                      AVMetadataObject.ObjectType.code128,
-                                      AVMetadataObject.ObjectType.ean8,
-                                      AVMetadataObject.ObjectType.ean13,
-                                      AVMetadataObject.ObjectType.aztec,
-                                      AVMetadataObject.ObjectType.pdf417,
-                                      AVMetadataObject.ObjectType.itf14,
-                                      AVMetadataObject.ObjectType.dataMatrix,
-                                      AVMetadataObject.ObjectType.interleaved2of5,
-                                      AVMetadataObject.ObjectType.qr]
+    private var supportedCodeTypes = ALL_FORMATS
+  
     public var delegate: ScanBarcodeDelegate? = nil
     private var captureSession = AVCaptureSession()
     private var videoPreviewLayer: AVCaptureVideoPreviewLayer?
@@ -182,7 +220,7 @@ class BarcodeScannerViewController: UIViewController {
     private var isOrientationPortrait = true
     var screenHeight:CGFloat = 0
     let captureMetadataOutput = AVCaptureMetadataOutput()
-    
+      
     private lazy var xCor: CGFloat! = {
         return self.isOrientationPortrait ? (screenSize.width - (screenSize.width*0.8))/2 :
             (screenSize.width - (screenSize.width*0.6))/2
@@ -579,6 +617,20 @@ class BarcodeScannerViewController: UIViewController {
             })
         }
     }
+  
+  
+    public func setScanFormat(format: ScanFormat){
+      var supportedFormats = ALL_FORMATS
+      switch format {
+        case ScanFormat.ONLY_BARCODE:
+          supportedFormats = ONLY_BARCODE
+        case ScanFormat.ONLY_QR_CODE:
+          supportedFormats = ONLY_QR_CODE
+        default:
+          supportedFormats = ALL_FORMATS
+      }
+      supportedCodeTypes = supportedFormats
+  }
 }
 
 /// Extension for view controller

--- a/lib/enum.dart
+++ b/lib/enum.dart
@@ -1,3 +1,5 @@
 enum ScanType { qr, barcode, defaultMode }
 
+enum ScanFormat { ALL_FORMATS, ONLY_QR_CODE, ONLY_BARCODE }
+
 enum CameraFace { back, front }

--- a/lib/flutter_barcode_scanner.dart
+++ b/lib/flutter_barcode_scanner.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 
 import 'package:flutter/services.dart';
 
+import 'enum.dart';
+
 /// Please note that this code is reimplementation of https://github.com/AmolGangadhare/flutter_barcode_scanner, since
 /// the package is not updated for quite sometime, I have added here
 /// Scan mode which is either QR code or BARCODE
@@ -26,12 +28,14 @@ class FlutterBarcodeScanner {
   /// displayed if [isShowFlashIcon] is true. The text of the cancel button can
   /// be customized with the [cancelButtonText] string.
   static Future<String> scanBarcode(
-      String lineColor,
-      String cancelButtonText,
-      bool isShowFlashIcon,
-      ScanMode scanMode,
-      int? delayMillis,
-      String cameraFace) async {
+    String lineColor,
+    String cancelButtonText,
+    bool isShowFlashIcon,
+    ScanMode scanMode,
+    int? delayMillis,
+    String cameraFace,
+    ScanFormat scanFormat,
+  ) async {
     if (cancelButtonText.isEmpty) {
       cancelButtonText = 'Cancel';
     }
@@ -44,7 +48,8 @@ class FlutterBarcodeScanner {
       'isContinuousScan': false,
       'scanMode': scanMode.index,
       'delayMillis': delayMillis ?? 0,
-      'cameraFacingText': cameraFace
+      'cameraFacingText': cameraFace,
+      'scanFormat': scanFormat.name,
     };
 
     /// Get barcode scan result
@@ -61,12 +66,14 @@ class FlutterBarcodeScanner {
   /// be customized with the [cancelButtonText] string. Returns a stream of
   /// detected barcode strings.
   static Stream? getBarcodeStreamReceiver(
-      String lineColor,
-      String cancelButtonText,
-      bool isShowFlashIcon,
-      ScanMode scanMode,
-      int? delayMillis,
-      String cameraFace) {
+    String lineColor,
+    String cancelButtonText,
+    bool isShowFlashIcon,
+    ScanMode scanMode,
+    int? delayMillis,
+    String cameraFace,
+    ScanFormat scanFormat,
+  ) {
     if (cancelButtonText.isEmpty) {
       cancelButtonText = 'Cancel';
     }
@@ -79,7 +86,8 @@ class FlutterBarcodeScanner {
       'isContinuousScan': true,
       'scanMode': scanMode.index,
       'delayMillis': delayMillis ?? 0,
-      'cameraFacingText': cameraFace
+      'cameraFacingText': cameraFace,
+      'scanFormat': scanFormat.name,
     };
 
     // Invoke method to open camera, and then create an event channel which will

--- a/lib/screens/io_device.dart
+++ b/lib/screens/io_device.dart
@@ -25,20 +25,24 @@ class BarcodeScanner extends StatelessWidget {
   final BarcodeAppBar? barcodeAppBar;
   final int? delayMillis;
   final Function? onClose;
-  const BarcodeScanner(
-      {super.key,
-      required this.lineColor,
-      required this.cancelButtonText,
-      required this.isShowFlashIcon,
-      required this.scanType,
-      this.cameraFace = CameraFace.back,
-      required this.onScanned,
-      this.child,
-      this.appBarTitle,
-      this.centerTitle,
-      this.barcodeAppBar,
-      this.delayMillis,
-      this.onClose});
+  final ScanFormat scanFormat;
+
+  const BarcodeScanner({
+    super.key,
+    required this.lineColor,
+    required this.cancelButtonText,
+    required this.isShowFlashIcon,
+    required this.scanType,
+    this.cameraFace = CameraFace.back,
+    required this.onScanned,
+    this.child,
+    this.appBarTitle,
+    this.centerTitle,
+    this.barcodeAppBar,
+    this.delayMillis,
+    this.onClose,
+    this.scanFormat = ScanFormat.ALL_FORMATS,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -90,6 +94,7 @@ class BarcodeScanner extends StatelessWidget {
       scanMode,
       delayMillis,
       cameraFace.name.toUpperCase(),
+      scanFormat,
     );
     onScanned(barcode);
   }
@@ -102,6 +107,7 @@ class BarcodeScanner extends StatelessWidget {
       scanMode,
       delayMillis,
       cameraFace.name.toUpperCase(),
+      scanFormat,
     )?.listen((barcode) {
       if (barcode != null) {
         barcode == kCancelValue ? onClose?.call() : onScanned(barcode);
@@ -127,6 +133,7 @@ class BarcodeScannerView extends StatelessWidget {
   final int? delayMillis;
   final Function? onClose;
   final bool continuous;
+  final ScanFormat scanFormat;
   const BarcodeScannerView(
       {super.key,
       this.scannerWidth,
@@ -138,6 +145,7 @@ class BarcodeScannerView extends StatelessWidget {
       this.child,
       this.delayMillis,
       this.onClose,
+      this.scanFormat = ScanFormat.ALL_FORMATS,
       required this.onBarcodeViewCreated});
 
   @override
@@ -154,6 +162,7 @@ class BarcodeScannerView extends StatelessWidget {
             'continuous': continuous,
             'scannerWidth': scannerWidth?.toInt(),
             'scannerHeight': scannerHeight?.toInt(),
+            'scanFormat': scanFormat.name,
           },
           creationParamsCodec: const StandardMessageCodec(),
         );
@@ -168,6 +177,7 @@ class BarcodeScannerView extends StatelessWidget {
             'continuous': continuous,
             'scannerWidth': scannerWidth?.toInt(),
             'scannerHeight': scannerHeight?.toInt(),
+            'scanFormat': scanFormat.name,
           },
           creationParamsCodec: const StandardMessageCodec(),
         );

--- a/lib/screens/unsupported.dart
+++ b/lib/screens/unsupported.dart
@@ -16,20 +16,23 @@ class BarcodeScanner extends StatelessWidget {
   final BarcodeAppBar? barcodeAppBar;
   final int? delayMillis;
   final Function? onClose;
-  const BarcodeScanner(
-      {super.key,
-      this.lineColor = "#ff6666",
-      this.cancelButtonText = "Cancel",
-      this.isShowFlashIcon = false,
-      this.scanType = ScanType.barcode,
-      this.cameraFace = CameraFace.back,
-      required this.onScanned,
-      this.appBarTitle,
-      this.child,
-      this.centerTitle,
-      this.barcodeAppBar,
-      this.delayMillis,
-      this.onClose});
+  final ScanFormat scanFormat;
+  const BarcodeScanner({
+    super.key,
+    this.lineColor = "#ff6666",
+    this.cancelButtonText = "Cancel",
+    this.isShowFlashIcon = false,
+    this.scanType = ScanType.barcode,
+    this.cameraFace = CameraFace.back,
+    required this.onScanned,
+    this.appBarTitle,
+    this.child,
+    this.centerTitle,
+    this.barcodeAppBar,
+    this.delayMillis,
+    this.onClose,
+    this.scanFormat = ScanFormat.ALL_FORMATS,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -51,6 +54,7 @@ class BarcodeScannerView extends StatelessWidget {
   final bool continuous;
   final double? scannerWidth;
   final double? scannerHeight;
+  final ScanFormat scanFormat;
   const BarcodeScannerView(
       {super.key,
       this.scannerWidth,
@@ -62,6 +66,7 @@ class BarcodeScannerView extends StatelessWidget {
       this.child,
       this.delayMillis,
       this.onClose,
+      this.scanFormat = ScanFormat.ALL_FORMATS,
       required this.onBarcodeViewCreated});
 
   @override

--- a/lib/screens/web.dart
+++ b/lib/screens/web.dart
@@ -23,6 +23,7 @@ class BarcodeScanner extends StatelessWidget {
   final BarcodeAppBar? barcodeAppBar;
   final int? delayMillis;
   final Function? onClose;
+  final ScanFormat scanFormat;
 
   const BarcodeScanner({
     super.key,
@@ -38,6 +39,7 @@ class BarcodeScanner extends StatelessWidget {
     this.barcodeAppBar,
     this.delayMillis,
     this.onClose,
+    this.scanFormat = ScanFormat.ALL_FORMATS,
   });
 
   @override
@@ -130,6 +132,7 @@ class BarcodeScannerView extends StatelessWidget {
   final bool continuous;
   final double? scannerWidth;
   final double? scannerHeight;
+  final ScanFormat scanFormat;
   const BarcodeScannerView(
       {super.key,
       this.scannerWidth,
@@ -141,6 +144,7 @@ class BarcodeScannerView extends StatelessWidget {
       this.child,
       this.delayMillis,
       this.onClose,
+      this.scanFormat = ScanFormat.ALL_FORMATS,
       required this.onBarcodeViewCreated});
 
   @override

--- a/lib/simple_barcode_scanner.dart
+++ b/lib/simple_barcode_scanner.dart
@@ -127,6 +127,9 @@ class SimpleBarcodeScanner extends StatelessWidget {
   /// Callback function called when the scanner view is created.
   final BarcodeScannerViewCreated onBarcodeViewCreated;
 
+  /// The format of the barcode to scan. Default is ALL_FORMATS (e.g., ONLY_QR_CODE, ONLY_BARCODE). Only works on Android and iOS. Web will scan all formats.
+  final ScanFormat scanFormat;
+
   /// The width of the scanner view.
   final double? scaleWidth;
 
@@ -175,6 +178,7 @@ class SimpleBarcodeScanner extends StatelessWidget {
       this.onScanned,
       this.continuous = false,
       this.onClose,
+      this.scanFormat = ScanFormat.ALL_FORMATS,
       required this.onBarcodeViewCreated});
 
   /// Launches the barcode scanner interface and returns the scanned value.
@@ -205,6 +209,7 @@ class SimpleBarcodeScanner extends StatelessWidget {
     BarcodeAppBar? barcodeAppBar,
     int? delayMillis,
     Widget? child,
+    ScanFormat scanFormat = ScanFormat.ALL_FORMATS,
   }) async {
     return Navigator.push<String>(
       context,
@@ -217,8 +222,9 @@ class SimpleBarcodeScanner extends StatelessWidget {
           cameraFace: cameraFace,
           barcodeAppBar: barcodeAppBar,
           delayMillis: delayMillis,
-          child: child,
+          scanFormat: scanFormat,
           onScanned: (res) => Navigator.pop(context, res),
+          child: child,
         ),
       ),
     );
@@ -251,6 +257,7 @@ class SimpleBarcodeScanner extends StatelessWidget {
     CameraFace cameraFace = CameraFace.back,
     BarcodeAppBar? barcodeAppBar,
     int? delayMillis,
+    ScanFormat scanFormat = ScanFormat.ALL_FORMATS,
     Widget? child,
   }) {
     final streamController = StreamController<String>();
@@ -267,7 +274,7 @@ class SimpleBarcodeScanner extends StatelessWidget {
           cameraFace: cameraFace,
           barcodeAppBar: barcodeAppBar,
           delayMillis: delayMillis,
-          child: child,
+          scanFormat: scanFormat,
           onScanned: (res) {
             streamController.add(res);
             // Don't pop the navigator - keep scanning
@@ -279,6 +286,7 @@ class SimpleBarcodeScanner extends StatelessWidget {
               Navigator.pop(context);
             }
           },
+          child: child,
         ),
       ),
     );
@@ -298,6 +306,7 @@ class SimpleBarcodeScanner extends StatelessWidget {
       continuous: continuous,
       onClose: onClose,
       onBarcodeViewCreated: onBarcodeViewCreated,
+      scanFormat: scanFormat,
       child: child,
     );
   }


### PR DESCRIPTION
This update introduces a flexible scanning option (ScanFormat), allowing users to choose between scanning only barcodes, only QR codes, or both simultaneously.