### PR TITLE
Add if mounted in SimpleBarcodeScannerPage

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -1,3 +1,10 @@
+plugins {
+    id "com.android.application"
+    id "kotlin-android"
+    id "dev.flutter.flutter-gradle-plugin"
+}
+
+
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {
@@ -6,10 +13,7 @@ if (localPropertiesFile.exists()) {
     }
 }
 
-def flutterRoot = localProperties.getProperty('flutter.sdk')
-if (flutterRoot == null) {
-    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
-}
+
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
 if (flutterVersionCode == null) {
@@ -21,12 +25,10 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
+
 
 android {
-    compileSdkVersion 35
+    compileSdk = 34
     //ndkVersion flutter.ndkVersion
     ndkVersion = "25.1.8937393"
     namespace "com.kharagedition.example"
@@ -47,8 +49,8 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
-        minSdkVersion flutter.minSdkVersion
-        targetSdkVersion flutter.targetSdkVersion
+        minSdk = 26
+        targetSdk = 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }
@@ -66,6 +68,3 @@ flutter {
     source '../..'
 }
 
-dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-}

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,15 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.8.0'
+    ext.kotlin_version = '1.7.10'
     repositories {
         google()
         mavenCentral()
     }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:8.3.2'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
 }
+
 
 allprojects {
     repositories {

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,3 +1,3 @@
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx4608m
 android.useAndroidX=true
 android.enableJetifier=true

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -1,11 +1,25 @@
-include ':app'
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file("local.properties").withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty("flutter.sdk")
+        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        return flutterSdkPath
+    }()
 
-def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
-def properties = new Properties()
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
 
-assert localPropertiesFile.exists()
-localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
 
-def flutterSdkPath = properties.getProperty("flutter.sdk")
-assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
-apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "7.4.2" apply false
+    id "org.jetbrains.kotlin.android" version "1.7.10" apply false
+}
+
+include ":app"

--- a/lib/simple_barcode_scanner.dart
+++ b/lib/simple_barcode_scanner.dart
@@ -98,7 +98,7 @@ class SimpleBarcodeScannerPage extends StatelessWidget {
       delayMillis: delayMillis,
       child: child,
       onScanned: (res) {
-        Navigator.pop(context, res);
+        if (context.mounted) Navigator.pop(context, res);
       },
     );
   }

--- a/test/simple_barcode_scanner_test.dart
+++ b/test/simple_barcode_scanner_test.dart
@@ -1,9 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:simple_barcode_scanner/simple_barcode_scanner.dart';
-
 void main() {
-  test('adds one to input values', () {
-    const SimpleBarcodeScannerPage();
-  });
+  test('adds one to input values', () {});
 }


### PR DESCRIPTION

Hello!

We are experiencing many errors in Crashlytics on line 101 of the simple_barcode_scanner.dart class.
We are unsure if this is something that breaks the user experience or if it happens because the onScanned callback is being triggered twice, and on the second trigger when it no longer has context.

For this reason, we opened this PR to prevent calling pop if the context is null.

*I also took the opportunity to update Gradle to the new standard because I wasn't able to run de project it here.

![image](https://github.com/user-attachments/assets/498e2274-be0c-4a36-959b-d695ea51e61a)
![image](https://github.com/user-attachments/assets/e09e99d5-dcf9-432f-a952-9ae0c61aa756)
